### PR TITLE
remove customization from kinesis connector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.1" // current series x.y
+ThisBuild / tlBaseVersion := "0.2" // current series x.y
 
 ThisBuild / organization := "com.ocadotechnology"
 ThisBuild / organizationName := "Ocado Technology"
@@ -103,7 +103,6 @@ lazy val kinesis = module("kinesis", directory = "connectors")
     name := "pass4s-connector-kinesis",
     libraryDependencies ++= Seq(
       "io.laserdisc" %% "pure-kinesis-tagless" % "5.0.2",
-      "software.amazon.awssdk" % "sts" % "2.17.220"
     ) ++ awsSnykOverrides
   )
   .dependsOn(core)

--- a/connectors/kinesis/src/main/scala/com/ocadotechnology/pass4s/connectors/kinesis/KinesisConnector.scala
+++ b/connectors/kinesis/src/main/scala/com/ocadotechnology/pass4s/connectors/kinesis/KinesisConnector.scala
@@ -18,7 +18,6 @@ package com.ocadotechnology.pass4s.connectors.kinesis
 
 import cats.ApplicativeThrow
 import cats.effect.Async
-
 import cats.effect.Resource
 import cats.effect.Sync
 import cats.implicits._
@@ -27,23 +26,15 @@ import com.ocadotechnology.pass4s.core._
 import fs2.Stream
 import io.laserdisc.pure.kinesis.tagless.KinesisAsyncClientOp
 import io.laserdisc.pure.kinesis.tagless.{Interpreter => KinesisInterpreter}
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.core.SdkBytes
-import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClientBuilder
 import software.amazon.awssdk.services.kinesis.model.PutRecordRequest
-import software.amazon.awssdk.services.sts.StsClient
-import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
-import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
 
-import scala.concurrent.duration._
 import java.net.URI
 import java.util.UUID
-import scala.concurrent.duration.FiniteDuration
 import scala.reflect.runtime.universe._
 
 trait Kinesis
@@ -63,8 +54,6 @@ final case class KinesisDestination(name: String) extends Destination[Kinesis] {
 trait KinesisAttributesProvider[F[_]] {
   def getPartitionKey(payload: Payload, kinesisDestination: KinesisDestination): F[String]
 }
-
-final case class StsAuthorizationDetails(roleArn: String, awsKeyId: String, awsSecretAccessKey: String)
 
 object KinesisAttributesProvider {
   def apply[F[_]](implicit ev: KinesisAttributesProvider[F]): KinesisAttributesProvider[F] = ev
@@ -107,52 +96,6 @@ object KinesisConnector {
       val builder = KinesisAsyncClient.builder().region(region)
       endpointOverride.fold(builder)(builder.endpointOverride)
     }
-
-  /** Create Kinesis connector with specific authorization details. It can be used in case if you are connecting to other application
-    * Kinesis.
-    * @param region
-    *   AWS region
-    * @param endpointOverride
-    *   endpoint override for testing
-    * @param stsAuthorizationDetails
-    *   authorization details
-    * @param sessionName
-    *   session name
-    * @tparam F
-    *   effect type
-    * @return
-    *   KinesisConnector
-    */
-  def usingRegionAndConnectionDetails[F[_]: Async](
-    region: Region,
-    stsAuthorizationDetails: StsAuthorizationDetails,
-    sessionName: String,
-    endpointOverride: Option[URI] = None,
-    sessionDuration: FiniteDuration = 15.minutes
-  ): Resource[F, KinesisConnector[F]] =
-    for {
-      credentialsProvider <- CredentialsProvider.stsAssumeRoleCredentialsProviderResource[F](
-                               region = region,
-                               roleArn = stsAuthorizationDetails.roleArn,
-                               endpointOverride = endpointOverride,
-                               credentialsOverride = StaticCredentialsProvider
-                                 .create(
-                                   AwsBasicCredentials.create(
-                                     stsAuthorizationDetails.awsKeyId,
-                                     stsAuthorizationDetails.awsSecretAccessKey
-                                   )
-                                 ),
-                               sessionName = sessionName,
-                               sessionDuration = sessionDuration
-                             )
-      clientBuilder = KinesisAsyncClient
-                        .builder()
-                        .httpClient(NettyNioAsyncHttpClient.create())
-                        .credentialsProvider(credentialsProvider)
-                        .region(region)
-      clientWithEndpointOverride = endpointOverride.map(eo => clientBuilder.endpointOverride(eo)).getOrElse(clientBuilder)
-      connector           <- KinesisConnector.usingBuilderWithDefaultAttributesProvider[F](clientWithEndpointOverride)
-    } yield connector
 
   def usingRegionWithDefaultAttributesProvider[F[_]: Async](
     region: Region,
@@ -206,40 +149,6 @@ object KinesisConnector {
         }
 
     }
-
-  object CredentialsProvider {
-
-    def stsAssumeRoleCredentialsProviderResource[F[_]: Sync](
-      region: Region,
-      roleArn: String,
-      credentialsOverride: AwsCredentialsProvider,
-      sessionName: String,
-      endpointOverride: Option[URI],
-      sessionDuration: FiniteDuration
-    ): Resource[F, StsAssumeRoleCredentialsProvider] =
-      for {
-        stsClientWithEndpoint            <- Resource.fromAutoCloseable(Sync[F].delay {
-                                              val stsClientBuilder = StsClient.builder.region(region).credentialsProvider(credentialsOverride)
-                                              endpointOverride.fold(stsClientBuilder)(stsClientBuilder.endpointOverride).build()
-                                            })
-        assumeRoleRequest = AssumeRoleRequest
-                              .builder
-                              .roleArn(roleArn)
-                              .roleSessionName(sessionName)
-                              .durationSeconds(sessionDuration.toSeconds.toInt)
-                              .build()
-        stsAssumeRoleCredentialsProvider <- Resource.fromAutoCloseable(
-                                              Sync[F].delay( // This builder can start thread (depends on flags)
-                                                StsAssumeRoleCredentialsProvider
-                                                  .builder
-                                                  .stsClient(stsClientWithEndpoint)
-                                                  .refreshRequest(assumeRoleRequest)
-                                                  .build()
-                                              )
-                                            )
-      } yield stsAssumeRoleCredentialsProvider
-
-  }
 
 }
 


### PR DESCRIPTION
kinesis connector shouldn't depend on STS only because there is a code that looks like written for 1 use case. if needed user should construct their KinesisAsyncClient by themself and invoke KinesisConnector.usingBuilder