### PR TITLE
Clean up some code in IT tests

### DIFF
--- a/src/it/scala/com/ocadotechnology/pass4s/addons/s3proxy/S3ProxyTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/addons/s3proxy/S3ProxyTests.scala
@@ -4,7 +4,6 @@ import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.std.UUIDGen
 import com.ocadotechnology.pass4s.connectors.sns.Sns
-import com.ocadotechnology.pass4s.connectors.sns.SnsArn
 import com.ocadotechnology.pass4s.connectors.sns.SnsConnector
 import com.ocadotechnology.pass4s.connectors.sns.SnsDestination
 import com.ocadotechnology.pass4s.connectors.sns.SnsFifo
@@ -12,7 +11,6 @@ import com.ocadotechnology.pass4s.connectors.sqs.Sqs
 import com.ocadotechnology.pass4s.connectors.sqs.SqsConnector
 import com.ocadotechnology.pass4s.connectors.sqs.SqsEndpoint
 import com.ocadotechnology.pass4s.connectors.sqs.SqsFifo
-import com.ocadotechnology.pass4s.connectors.sqs.SqsUrl
 import com.ocadotechnology.pass4s.core.Message
 import com.ocadotechnology.pass4s.high.Broker
 import com.ocadotechnology.pass4s.kernel.Consumer
@@ -73,16 +71,11 @@ object S3ProxyTests extends MutableIOSuite {
             )
         val payload = Message.Payload("body", Map("foo" -> "bar"))
         val consumer: Consumer[IO, Message.Payload] =
-          broker
-            .consumer(SqsEndpoint(SqsUrl(queueUrl), SqsEndpoint.Settings()))
-            .usingS3Proxy(consumerConfig)
+          broker.consumer(SqsEndpoint(queueUrl)).usingS3Proxy(consumerConfig)
         val consume1MessageFromQueue =
           Consumer.toStreamSynchronous(consumer).head.compile.lastOrError
         val sendMessageOnTopic =
-          broker
-            .sender
-            .usingS3Proxy(senderConfig)
-            .sendOne(Message(payload, SnsDestination(SnsArn(topicArn))).widen)
+          broker.sender.usingS3Proxy(senderConfig).sendOne(Message(payload, SnsDestination(topicArn)).widen)
 
         for {
           _            <- sendMessageOnTopic
@@ -116,17 +109,11 @@ object S3ProxyTests extends MutableIOSuite {
             )
         val payload = Message.Payload("body", Map("foo" -> "bar"))
         val consumer: Consumer[IO, Message.Payload] =
-          broker
-            .consumer(SqsEndpoint(SqsUrl(queueUrl), SqsEndpoint.Settings(cancelableMessageProcessing = false)))
-            .usingS3Proxy(consumerConfig)
+          broker.consumer(SqsEndpoint(queueUrl, SqsEndpoint.Settings(cancelableMessageProcessing = false))).usingS3Proxy(consumerConfig)
         val consume1MessageFromQueue =
           Consumer.toStreamSynchronous(consumer).head.compile.lastOrError
         val sendMessageOnTopic =
-          broker
-            .sender
-            .usingS3Proxy(senderConfig)
-            .sendOne(Message(payload, SnsDestination(SnsArn(topicArn))).widen)
-
+          broker.sender.usingS3Proxy(senderConfig).sendOne(Message(payload, SnsDestination(topicArn)).widen)
         for {
           _            <- sendMessageOnTopic
           objects      <- s3Client.listObjects(bucketName)
@@ -155,11 +142,11 @@ object S3ProxyTests extends MutableIOSuite {
             .Consumer
             .withSnsDefaults()
         val payload = Message.Payload("body", Map("foo" -> "bar"))
-        val consumer = broker.consumer(SqsEndpoint(SqsUrl(queueUrl))).usingS3Proxy(consumerConfig)
+        val consumer = broker.consumer(SqsEndpoint(queueUrl)).usingS3Proxy(consumerConfig)
         val consume1MessageFromQueue =
           Consumer.toStreamSynchronous(consumer).head.compile.lastOrError
         val sender = broker.sender.usingS3Proxy(senderConfig)
-        val sendMessageOnTopic = sender.sendOne(Message(payload, SnsDestination(SnsArn(topicArn))).widen)
+        val sendMessageOnTopic = sender.sendOne(Message(payload, SnsDestination(topicArn)).widen)
 
         for {
           _       <- sendMessageOnTopic
@@ -185,7 +172,7 @@ object S3ProxyTests extends MutableIOSuite {
             )
         val payload = Message.Payload("body", Map("foo" -> "bar"))
         val sender = broker.sender.usingS3Proxy(senderConfig)
-        val sendMessageOnTopic = sender.sendOne(Message(payload, SnsDestination(SnsArn(topicArn))).widen)
+        val sendMessageOnTopic = sender.sendOne(Message(payload, SnsDestination(topicArn)).widen)
 
         for {
           initial <- s3Client.listObjects(bucketName)
@@ -217,8 +204,8 @@ object S3ProxyTests extends MutableIOSuite {
             )
         val payload = Message.Payload("body", Map("foo" -> "bar"))
         val sender = broker.sender.usingS3Proxy(senderConfig)
-        val sendMessageOnTopic = sender.sendOne(Message(payload, SnsDestination(SnsArn(topicArn))).widen)
-        val consumer = broker.consumer(SqsEndpoint(SqsUrl(queueUrl))).usingS3Proxy(consumerConfig)
+        val sendMessageOnTopic = sender.sendOne(Message(payload, SnsDestination(topicArn)).widen)
+        val consumer = broker.consumer(SqsEndpoint(queueUrl)).usingS3Proxy(consumerConfig)
 
         for {
           _       <- consumer.consume(_ => IO.raiseError(new RuntimeException("intentionally failed"))).background.use_

--- a/src/it/scala/com/ocadotechnology/pass4s/addons/s3proxy/S3ProxyTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/addons/s3proxy/S3ProxyTests.scala
@@ -5,28 +5,28 @@ import cats.effect.Resource
 import cats.effect.std.UUIDGen
 import com.ocadotechnology.pass4s.connectors.sns.Sns
 import com.ocadotechnology.pass4s.connectors.sns.SnsArn
+import com.ocadotechnology.pass4s.connectors.sns.SnsConnector
 import com.ocadotechnology.pass4s.connectors.sns.SnsDestination
 import com.ocadotechnology.pass4s.connectors.sns.SnsFifo
 import com.ocadotechnology.pass4s.connectors.sqs.Sqs
+import com.ocadotechnology.pass4s.connectors.sqs.SqsConnector
 import com.ocadotechnology.pass4s.connectors.sqs.SqsEndpoint
 import com.ocadotechnology.pass4s.connectors.sqs.SqsFifo
 import com.ocadotechnology.pass4s.connectors.sqs.SqsUrl
-import com.ocadotechnology.pass4s.connectors.util.LocalStackContainerUtils._
 import com.ocadotechnology.pass4s.core.Message
 import com.ocadotechnology.pass4s.high.Broker
 import com.ocadotechnology.pass4s.kernel.Consumer
 import com.ocadotechnology.pass4s.s3proxy.S3Client
 import com.ocadotechnology.pass4s.s3proxy.S3ProxyConfig
 import com.ocadotechnology.pass4s.s3proxy.syntax._
+import com.ocadotechnology.pass4s.util.LocalStackContainerUtils._
 import org.testcontainers.containers.localstack.LocalStackContainer.Service
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import weaver.MutableIOSuite
 
-import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration.DurationInt
-import com.ocadotechnology.pass4s.connectors.sns.SnsConnector
-import com.ocadotechnology.pass4s.connectors.sqs.SqsConnector
+import scala.concurrent.duration.FiniteDuration
 
 object S3ProxyTests extends MutableIOSuite {
 

--- a/src/it/scala/com/ocadotechnology/pass4s/connectors/jms/JmsRecoveryTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/connectors/jms/JmsRecoveryTests.scala
@@ -10,11 +10,11 @@ import cats.implicits._
 import com.ocadotechnology.pass4s.connectors.activemq.Jms
 import com.ocadotechnology.pass4s.connectors.activemq.JmsDestination
 import com.ocadotechnology.pass4s.connectors.activemq.JmsSource
-import com.ocadotechnology.pass4s.connectors.util.EmbeddedJmsBroker._
-import com.ocadotechnology.pass4s.connectors.util.ResourceAccess
 import com.ocadotechnology.pass4s.core.Message
 import com.ocadotechnology.pass4s.high.Broker
 import com.ocadotechnology.pass4s.kernel.Consumer
+import com.ocadotechnology.pass4s.util.EmbeddedJmsBroker._
+import com.ocadotechnology.pass4s.util.ResourceAccess
 import org.apache.activemq.broker.BrokerService
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger

--- a/src/it/scala/com/ocadotechnology/pass4s/connectors/jms/JmsTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/connectors/jms/JmsTests.scala
@@ -2,15 +2,14 @@ package com.ocadotechnology.pass4s.connectors.jms
 
 import cats.effect.IO
 import cats.effect.Resource
-import cats.implicits._
 import com.ocadotechnology.pass4s.connectors.activemq.Jms
 import com.ocadotechnology.pass4s.connectors.activemq.JmsDestination
 import com.ocadotechnology.pass4s.connectors.activemq.JmsSource
 import com.ocadotechnology.pass4s.connectors.activemq.JmsSource.JmsSourceSettings
-import com.ocadotechnology.pass4s.connectors.util.EmbeddedJmsBroker._
 import com.ocadotechnology.pass4s.core.Message
 import com.ocadotechnology.pass4s.high.Broker
 import com.ocadotechnology.pass4s.kernel.Consumer
+import com.ocadotechnology.pass4s.util.EmbeddedJmsBroker._
 import fs2.concurrent.SignallingRef
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger

--- a/src/it/scala/com/ocadotechnology/pass4s/connectors/kinesis/KinesisTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/connectors/kinesis/KinesisTests.scala
@@ -3,9 +3,9 @@ package com.ocadotechnology.pass4s.connectors.kinesis
 import cats.effect.IO
 import cats.effect.Resource
 import cats.implicits._
-import com.ocadotechnology.pass4s.connectors.util.LocalStackContainerUtils._
 import com.ocadotechnology.pass4s.core.Message
 import com.ocadotechnology.pass4s.high.Broker
+import com.ocadotechnology.pass4s.util.LocalStackContainerUtils._
 import io.laserdisc.pure.kinesis.tagless.KinesisAsyncClientOp
 import org.testcontainers.containers.localstack.LocalStackContainer.Service
 import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest

--- a/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SnsTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SnsTests.scala
@@ -63,7 +63,7 @@ object SnsTests extends MutableIOSuite {
       val payloads =
         0L.until(numMessages).map(n => Message.Payload(s"body$n", Map(SnsFifo.groupIdMetadata -> (n % 2).toString, "foo" -> "bar"))).toList
 
-      fifoTopicWithSubscriptionResource(snsClient, sqsClient)("fifo-topic")
+      topicWithSubscriptionResource(snsClient, sqsClient)("fifo-topic", isFifo = true)
         .use { case (topicArn, queueUrl) =>
           val consume10MessagesFromQueue =
             Consumer
@@ -92,7 +92,7 @@ object SnsTests extends MutableIOSuite {
 
     val payload = Foo(2137, order = "uśmiechu")
 
-    fifoTopicWithSubscriptionResource(snsClient, sqsClient)("another-fifo-topic")
+    topicWithSubscriptionResource(snsClient, sqsClient)("fifo-topic", isFifo = true)
       .use { case (topicArn, queueUrl) =>
         import com.ocadotechnology.pass4s.circe.syntax._
         val sender: Sender[IO, Foo] = broker.sender.asJsonSenderWithMessageGroup[Foo](SnsFifoDestination(SnsArn(topicArn)))

--- a/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SnsTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SnsTests.scala
@@ -14,20 +14,20 @@ import com.ocadotechnology.pass4s.connectors.sqs.SqsEndpoint
 import com.ocadotechnology.pass4s.connectors.sqs.SqsFifo
 import com.ocadotechnology.pass4s.connectors.sqs.SqsFifoEndpoint
 import com.ocadotechnology.pass4s.connectors.sqs.SqsUrl
-import com.ocadotechnology.pass4s.connectors.util.LocalStackContainerUtils._
 import com.ocadotechnology.pass4s.core.Message
 import com.ocadotechnology.pass4s.core.groupId.MessageGroup
 import com.ocadotechnology.pass4s.high.Broker
 import com.ocadotechnology.pass4s.kernel.Consumer
 import com.ocadotechnology.pass4s.kernel.Sender
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
+import com.ocadotechnology.pass4s.util.LocalStackContainerUtils._
 import io.circe.Encoder
 import io.circe.Json
 import io.circe.syntax.EncoderOps
 import io.laserdisc.pure.sns.tagless.SnsAsyncClientOp
 import io.laserdisc.pure.sqs.tagless.SqsAsyncClientOp
 import org.testcontainers.containers.localstack.LocalStackContainer.Service
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import weaver.MutableIOSuite
 
 object SnsTests extends MutableIOSuite {

--- a/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SqsRecoveryTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SqsRecoveryTests.scala
@@ -1,9 +1,8 @@
 package com.ocadotechnology.pass4s.connectors.snssqs
 
-import cats.implicits._
 import cats.effect.IO
 import cats.effect.Resource
-import com.ocadotechnology.pass4s.connectors.util.MockServerContainerUtils._
+import cats.implicits._
 import com.ocadotechnology.pass4s.connectors.sqs.Sqs
 import com.ocadotechnology.pass4s.connectors.sqs.SqsClientException
 import com.ocadotechnology.pass4s.connectors.sqs.SqsConnector
@@ -11,8 +10,7 @@ import com.ocadotechnology.pass4s.connectors.sqs.SqsEndpoint
 import com.ocadotechnology.pass4s.connectors.sqs.SqsUrl
 import com.ocadotechnology.pass4s.high.Broker
 import com.ocadotechnology.pass4s.kernel.Consumer
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
+import com.ocadotechnology.pass4s.util.MockServerContainerUtils._
 import org.apache.commons.codec.digest.DigestUtils
 import org.mockserver.client.MockServerClient
 import org.mockserver.matchers.Times
@@ -22,6 +20,8 @@ import org.mockserver.model.HttpResponse
 import org.mockserver.model.HttpResponse.response
 import org.mockserver.model.Parameter.param
 import org.mockserver.model.ParameterBody.params
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region

--- a/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SqsTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SqsTests.scala
@@ -10,23 +10,23 @@ import com.ocadotechnology.pass4s.connectors.sqs.SqsEndpoint
 import com.ocadotechnology.pass4s.connectors.sqs.SqsFifo
 import com.ocadotechnology.pass4s.connectors.sqs.SqsFifoEndpoint
 import com.ocadotechnology.pass4s.connectors.sqs.SqsUrl
-import com.ocadotechnology.pass4s.connectors.util.LocalStackContainerUtils._
 import com.ocadotechnology.pass4s.core.Message
 import com.ocadotechnology.pass4s.high.Broker
 import com.ocadotechnology.pass4s.kernel.Consumer
+import com.ocadotechnology.pass4s.util.LocalStackContainerUtils._
 import fs2.concurrent.SignallingRef
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.laserdisc.pure.sqs.tagless.SqsAsyncClientOp
 import org.testcontainers.containers.localstack.LocalStackContainer.Service
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import weaver.MutableIOSuite
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 object SqsTests extends MutableIOSuite {
   override type Res = (Broker[IO, Sqs with SqsFifo], SqsAsyncClientOp[IO])

--- a/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SqsTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SqsTests.scala
@@ -44,15 +44,15 @@ object SqsTests extends MutableIOSuite {
       .use { queueUrl =>
         val sendMessageRequest = SendMessageRequest
           .builder()
-          .queueUrl(queueUrl)
+          .queueUrl(queueUrl.value)
           .messageBody("foo")
           .messageAttributes(messageAttributes("foo" -> "bar").asJava)
           .build()
 
         val consume1MessageFromQueue =
-          Consumer.toStreamBounded(maxSize = 1)(broker.consumer(SqsEndpoint(SqsUrl(queueUrl)))).head.compile.lastOrError
+          Consumer.toStreamBounded(maxSize = 1)(broker.consumer(SqsEndpoint(queueUrl))).head.compile.lastOrError
         val sendMessageOnQueue = client.sendMessage(sendMessageRequest)
-        val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
+        val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl.value).build())
 
         (consume1MessageFromQueue <& sendMessageOnQueue).product(readCurrentQueueMessages)
       }
@@ -75,7 +75,7 @@ object SqsTests extends MutableIOSuite {
           def sendMessageRequest(body: String, groupId: String) =
             SendMessageRequest
               .builder()
-              .queueUrl(queueUrl)
+              .queueUrl(queueUrl.value)
               .messageBody(body)
               .messageGroupId(groupId) // this would normally be inserted automatically by SQS sender
               .messageAttributes(messageAttributes(SqsFifo.groupIdMetadata -> groupId, "foo" -> "bar").asJava)
@@ -84,13 +84,9 @@ object SqsTests extends MutableIOSuite {
           val requests = bodiesAndGroups.map((sendMessageRequest _).tupled)
 
           val consume10MessagesFromQueue =
-            Consumer
-              .toStreamBounded(maxSize = 1)(broker.consumer(SqsFifoEndpoint(SqsUrl(queueUrl))))
-              .take(numMessages)
-              .compile
-              .toList
+            Consumer.toStreamBounded(maxSize = 1)(broker.consumer(SqsFifoEndpoint(queueUrl))).take(numMessages).compile.toList
           val sendMessagesOnQueue = requests.traverse(client.sendMessage)
-          val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
+          val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl.value).build())
 
           (consume10MessagesFromQueue <& sendMessagesOnQueue).product(readCurrentQueueMessages)
         }
@@ -119,7 +115,7 @@ object SqsTests extends MutableIOSuite {
           def sendMessageRequest(body: String, groupId: String) =
             SendMessageRequest
               .builder()
-              .queueUrl(queueUrl)
+              .queueUrl(queueUrl.value)
               .messageBody(body)
               .messageGroupId(groupId) // this would normally be inserted automatically by SQS sender
               .messageAttributes(messageAttributes(SqsFifo.groupIdMetadata -> groupId, "foo" -> "bar").asJava)
@@ -128,13 +124,9 @@ object SqsTests extends MutableIOSuite {
           val requests = bodiesAndGroups.map((sendMessageRequest _).tupled)
 
           val consumeMessagesFromQueue =
-            Consumer
-              .toStreamBounded(maxSize = 1)(broker.consumer(SqsFifoEndpoint(SqsUrl(queueUrl))))
-              .take(2)
-              .compile
-              .toList
+            Consumer.toStreamBounded(maxSize = 1)(broker.consumer(SqsFifoEndpoint(queueUrl))).take(2).compile.toList
           val sendMessagesOnQueue = requests.traverse_(client.sendMessage)
-          val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
+          val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl.value).build())
 
           (consumeMessagesFromQueue <& sendMessagesOnQueue).product(readCurrentQueueMessages)
         }
@@ -151,11 +143,11 @@ object SqsTests extends MutableIOSuite {
       .product(Resource.eval(SignallingRef(0)))
       .use { case (queueUrl, signallingRef) =>
         val incrementingQueueConsumer =
-          broker.consumer(SqsEndpoint(SqsUrl(queueUrl), SqsEndpoint.Settings(maxConcurrent = 2))).consume { _ =>
+          broker.consumer(SqsEndpoint(queueUrl, SqsEndpoint.Settings(maxConcurrent = 2))).consume { _ =>
             signallingRef.update(_ + 1) *> IO.sleep(500.millis) *> signallingRef.update(_ - 1)
           }
         val listenOnChangesInSignallingRefUntilAllConsumed = signallingRef.discrete.drop(1).takeThrough(_ != 0).compile.toList
-        val sendMessageOnQueue = client.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody("foo").build())
+        val sendMessageOnQueue = client.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl.value).messageBody("foo").build())
 
         incrementingQueueConsumer
           .background
@@ -166,15 +158,15 @@ object SqsTests extends MutableIOSuite {
 
   test("when consumer is failing message should not be deleted").usingRes { case (broker, client) =>
     queueResource(client)("input-dlq")
-      .mproduct(dlqUrl => queueResource(client)("input-queue", _.attributes(redrivePolicy(dlqUrl).asJava)))
+      .mproduct(dlqUrl => queueResource(client)("input-queue", _.attributes(redrivePolicy(dlqUrl.value).asJava)))
       .use { case (dlqUrl, queueUrl) =>
         val failingQueueConsumer = broker
-          .consumer(SqsEndpoint(SqsUrl(queueUrl), SqsEndpoint.Settings(messageProcessingTimeout = 1.second)))
+          .consumer(SqsEndpoint(queueUrl, SqsEndpoint.Settings(messageProcessingTimeout = 1.second)))
           .consume(_ => IO.raiseError(new Exception("processing failed")))
         val consume1MessageFromDlq =
-          Consumer.toStreamBounded(maxSize = 1)(broker.consumer(SqsEndpoint(SqsUrl(dlqUrl)))).head.compile.lastOrError
-        val sendMessageOnQueue = client.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody("foo").build())
-        val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
+          Consumer.toStreamBounded(maxSize = 1)(broker.consumer(SqsEndpoint(dlqUrl))).head.compile.lastOrError
+        val sendMessageOnQueue = client.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl.value).messageBody("foo").build())
+        val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl.value).build())
 
         failingQueueConsumer
           .background
@@ -189,15 +181,15 @@ object SqsTests extends MutableIOSuite {
   test("when consumer is processing message for too long, then processing should be interrupted and message should not be deleted")
     .usingRes { case (broker, client) =>
       queueResource(client)("input-dlq")
-        .mproduct(dlqUrl => queueResource(client)("input-queue", _.attributes(redrivePolicy(dlqUrl).asJava)))
+        .mproduct(dlqUrl => queueResource(client)("input-queue", _.attributes(redrivePolicy(dlqUrl.value).asJava)))
         .use { case (dlqUrl, queueUrl) =>
           val longProcessingQueueConsumer = broker
-            .consumer(SqsEndpoint(SqsUrl(queueUrl), SqsEndpoint.Settings(messageProcessingTimeout = 1.second)))
+            .consumer(SqsEndpoint(queueUrl, SqsEndpoint.Settings(messageProcessingTimeout = 1.second)))
             .consume(_ => IO.sleep(10.seconds))
           val consume1MessageFromDlq =
-            Consumer.toStreamBounded(maxSize = 1)(broker.consumer(SqsEndpoint(SqsUrl(dlqUrl)))).head.compile.lastOrError
-          val sendMessageOnQueue = client.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody("foo").build())
-          val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
+            Consumer.toStreamBounded(maxSize = 1)(broker.consumer(SqsEndpoint(dlqUrl))).head.compile.lastOrError
+          val sendMessageOnQueue = client.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl.value).messageBody("foo").build())
+          val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl.value).build())
 
           longProcessingQueueConsumer
             .background
@@ -214,9 +206,9 @@ object SqsTests extends MutableIOSuite {
     queueResource(client)("input-output-queue")
       .use { queueUrl =>
         val consume1MessageFromQueue =
-          Consumer.toStreamBounded(maxSize = 1)(broker.consumer(SqsEndpoint(SqsUrl(queueUrl)))).head.compile.lastOrError
-        val sendMessageOnQueue = broker.sender.sendOne(Message(payload, SqsDestination(SqsUrl(queueUrl))))
-        val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
+          Consumer.toStreamBounded(maxSize = 1)(broker.consumer(SqsEndpoint(queueUrl))).head.compile.lastOrError
+        val sendMessageOnQueue = broker.sender.sendOne(Message(payload, SqsDestination(queueUrl)))
+        val readCurrentQueueMessages = client.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl.value).build())
 
         (consume1MessageFromQueue <& sendMessageOnQueue).product(readCurrentQueueMessages)
       }

--- a/src/it/scala/com/ocadotechnology/pass4s/util/EmbeddedJmsBroker.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/util/EmbeddedJmsBroker.scala
@@ -1,4 +1,4 @@
-package com.ocadotechnology.pass4s.connectors.util
+package com.ocadotechnology.pass4s.util
 
 import akka.actor.ActorSystem
 

--- a/src/it/scala/com/ocadotechnology/pass4s/util/LocalStackContainerUtils.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/util/LocalStackContainerUtils.scala
@@ -127,30 +127,12 @@ object LocalStackContainerUtils {
     snsClient: SnsAsyncClientOp[IO],
     sqsClient: SqsAsyncClientOp[IO]
   )(
-    topicName: String
+    topicName: String,
+    isFifo: Boolean = false
   ): Resource[IO, (String, String)] =
     for {
-      topicArn <- topicResource(snsClient)(topicName)
-      queueUrl <- queueResource(sqsClient)(s"$topicName-sub")
-      subscribeRequest = SubscribeRequest
-                           .builder()
-                           .topicArn(topicArn)
-                           .protocol("sqs")
-                           .endpoint(queueUrl)
-                           .attributes(Map("RawMessageDelivery" -> "true").asJava)
-                           .build()
-      _        <- Resource.eval(snsClient.subscribe(subscribeRequest))
-    } yield (topicArn, queueUrl)
-
-  def fifoTopicWithSubscriptionResource(
-    snsClient: SnsAsyncClientOp[IO],
-    sqsClient: SqsAsyncClientOp[IO]
-  )(
-    topicName: String
-  ): Resource[IO, (String, String)] =
-    for {
-      topicArn <- topicResource(snsClient)(topicName, isFifo = true)
-      queueUrl <- queueResource(sqsClient)(s"$topicName-sub", isFifo = true)
+      topicArn <- topicResource(snsClient)(topicName, isFifo = isFifo)
+      queueUrl <- queueResource(sqsClient)(s"$topicName-sub", isFifo = isFifo)
       subscribeRequest = SubscribeRequest
                            .builder()
                            .topicArn(topicArn)

--- a/src/it/scala/com/ocadotechnology/pass4s/util/LocalStackContainerUtils.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/util/LocalStackContainerUtils.scala
@@ -1,4 +1,4 @@
-package com.ocadotechnology.pass4s.connectors.util
+package com.ocadotechnology.pass4s.util
 
 import cats.Endo
 import cats.effect.IO

--- a/src/it/scala/com/ocadotechnology/pass4s/util/LocalStackContainerUtils.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/util/LocalStackContainerUtils.scala
@@ -7,9 +7,11 @@ import cats.implicits._
 import com.dimafeng.testcontainers.LocalStackV2Container
 import com.ocadotechnology.pass4s.connectors.kinesis.KinesisConnector
 import com.ocadotechnology.pass4s.connectors.kinesis.KinesisConnector.KinesisConnector
+import com.ocadotechnology.pass4s.connectors.sns.SnsArn
 import com.ocadotechnology.pass4s.connectors.sns.SnsConnector
 import com.ocadotechnology.pass4s.connectors.sns.SnsConnector.SnsConnector
 import com.ocadotechnology.pass4s.connectors.sqs.SqsConnector
+import com.ocadotechnology.pass4s.connectors.sqs.SqsUrl
 import com.ocadotechnology.pass4s.connectors.sqs.SqsConnector.SqsConnector
 import com.ocadotechnology.pass4s.s3proxy.S3Client
 import io.laserdisc.pure.kinesis.tagless.KinesisAsyncClientOp
@@ -88,23 +90,25 @@ object LocalStackContainerUtils {
     additionalParameters: Endo[CreateQueueRequest.Builder] = identity,
     isFifo: Boolean = false,
     isDedup: Boolean = false
-  ): Resource[IO, String] =
-    Resource.make(for {
-      randomSuffix <- IO(Random.alphanumeric.take(8).mkString)
-      fifoSuffix = if (isFifo) ".fifo" else ""
-      fifoAttrs = Map(QueueAttributeName.FIFO_QUEUE -> isFifo.toString)
-      attrs = if (isDedup)
-                fifoAttrs ++ Map(
-                  QueueAttributeName.DEDUPLICATION_SCOPE -> "messageGroup",
-                  QueueAttributeName.CONTENT_BASED_DEDUPLICATION -> true.toString
-                )
-              else fifoAttrs
-      response     <- sqsClient.createQueue(
-                        additionalParameters(
-                          CreateQueueRequest.builder().queueName(s"$queueName-$randomSuffix$fifoSuffix").attributes(attrs.asJava)
-                        ).build()
-                      )
-    } yield response.queueUrl())(queueUrl => sqsClient.deleteQueue(DeleteQueueRequest.builder().queueUrl(queueUrl).build()).void)
+  ): Resource[IO, SqsUrl] =
+    Resource
+      .make(for {
+        randomSuffix <- IO(Random.alphanumeric.take(8).mkString)
+        fifoSuffix = if (isFifo) ".fifo" else ""
+        fifoAttrs = Map(QueueAttributeName.FIFO_QUEUE -> isFifo.toString)
+        attrs = if (isDedup)
+                  fifoAttrs ++ Map(
+                    QueueAttributeName.DEDUPLICATION_SCOPE -> "messageGroup",
+                    QueueAttributeName.CONTENT_BASED_DEDUPLICATION -> true.toString
+                  )
+                else fifoAttrs
+        response     <- sqsClient.createQueue(
+                          additionalParameters(
+                            CreateQueueRequest.builder().queueName(s"$queueName-$randomSuffix$fifoSuffix").attributes(attrs.asJava)
+                          ).build()
+                        )
+      } yield response.queueUrl())(queueUrl => sqsClient.deleteQueue(DeleteQueueRequest.builder().queueUrl(queueUrl).build()).void)
+      .map(SqsUrl)
 
   def topicResource(
     snsClient: SnsAsyncClientOp[IO]
@@ -112,16 +116,18 @@ object LocalStackContainerUtils {
     topicName: String,
     additionalParameters: Endo[CreateTopicRequest.Builder] = identity,
     isFifo: Boolean = false
-  ): Resource[IO, String] =
-    Resource.make(for {
-      randomSuffix <- IO(Random.alphanumeric.take(8).mkString)
-      fifoSuffix = if (isFifo) ".fifo" else ""
-      attrs = Map("FifoTopic" -> isFifo.toString)
-      response     <-
-        snsClient.createTopic(
-          additionalParameters(CreateTopicRequest.builder().name(s"$topicName-$randomSuffix$fifoSuffix").attributes(attrs.asJava)).build()
-        )
-    } yield response.topicArn())(topicArn => snsClient.deleteTopic(DeleteTopicRequest.builder().topicArn(topicArn).build()).void)
+  ): Resource[IO, SnsArn] =
+    Resource
+      .make(for {
+        randomSuffix <- IO(Random.alphanumeric.take(8).mkString)
+        fifoSuffix = if (isFifo) ".fifo" else ""
+        attrs = Map("FifoTopic" -> isFifo.toString)
+        response     <-
+          snsClient.createTopic(
+            additionalParameters(CreateTopicRequest.builder().name(s"$topicName-$randomSuffix$fifoSuffix").attributes(attrs.asJava)).build()
+          )
+      } yield response.topicArn())(topicArn => snsClient.deleteTopic(DeleteTopicRequest.builder().topicArn(topicArn).build()).void)
+      .map(SnsArn)
 
   def topicWithSubscriptionResource(
     snsClient: SnsAsyncClientOp[IO],
@@ -129,15 +135,15 @@ object LocalStackContainerUtils {
   )(
     topicName: String,
     isFifo: Boolean = false
-  ): Resource[IO, (String, String)] =
+  ): Resource[IO, (SnsArn, SqsUrl)] =
     for {
       topicArn <- topicResource(snsClient)(topicName, isFifo = isFifo)
       queueUrl <- queueResource(sqsClient)(s"$topicName-sub", isFifo = isFifo)
       subscribeRequest = SubscribeRequest
                            .builder()
-                           .topicArn(topicArn)
+                           .topicArn(topicArn.value)
                            .protocol("sqs")
-                           .endpoint(queueUrl)
+                           .endpoint(queueUrl.value)
                            .attributes(Map("RawMessageDelivery" -> "true").asJava)
                            .build()
       _        <- Resource.eval(snsClient.subscribe(subscribeRequest))

--- a/src/it/scala/com/ocadotechnology/pass4s/util/MockServerContainerUtils.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/util/MockServerContainerUtils.scala
@@ -1,4 +1,4 @@
-package com.ocadotechnology.pass4s.connectors.util
+package com.ocadotechnology.pass4s.util
 
 import cats.effect.IO
 import cats.effect.Resource

--- a/src/it/scala/com/ocadotechnology/pass4s/util/ResourceAccess.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/util/ResourceAccess.scala
@@ -1,4 +1,4 @@
-package com.ocadotechnology.pass4s.connectors.util
+package com.ocadotechnology.pass4s.util
 
 import cats.effect.IO
 import cats.effect.Resource

--- a/src/it/scala/com/ocadotechnology/pass4s/util/TestContainersUtils.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/util/TestContainersUtils.scala
@@ -1,4 +1,4 @@
-package com.ocadotechnology.pass4s.connectors.util
+package com.ocadotechnology.pass4s.util
 
 import cats.effect.IO
 import cats.effect.Resource


### PR DESCRIPTION
best to review commit after commit:
* move util in IT to com.ocadotechnology.pass4s.util (utils regarding localstack are not necessary related with `.connectors` package)
* remove redundant fifoTopicWithSubscriptionResource (DRY)
* return new-type from functions constructing SQS / SNS (type `(SnsArn, SqsUrl)` is more descriptive than `(String, String)`)