### PR TITLE
add widen to Destination

### DIFF
--- a/core/src/main/scala/com/ocadotechnology/pass4s/core/core.scala
+++ b/core/src/main/scala/com/ocadotechnology/pass4s/core/core.scala
@@ -63,7 +63,9 @@ trait Source[P] extends End[P] {
   def maxConcurrent: Int = 1
 }
 
-trait Destination[P] extends End[P]
+trait Destination[P] extends End[P] {
+  def widen[R <: P]: Destination[R] = this.asInstanceOf[Destination[R]]
+}
 
 trait CommittableMessage[F[_]] { self =>
   def scope: Resource[F, Payload]


### PR DESCRIPTION
useful, same as `widen` method in `Message` class

allows to convert `Destination[Foo]` to `Destination[Foo with Bar]` if needed (eg collecting all destinations into a single list)