### PR TITLE
Add scala steward ignore rules for typesafe and lightbend

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,6 @@
+updates.ignore = [
+  # https://www.lightbend.com/blog/why-we-are-changing-the-license-for-akka
+  { groupId = "com.typesafe.akka" },
+  { groupId = "com.lightbend.akka" },
+  { groupId = "com.lightbend.akka.grpc" }
+]


### PR DESCRIPTION
Since Lightbend has [changed their licence for akka](https://www.lightbend.com/blog/why-we-are-changing-the-license-for-akka), we are freezign the dependency