### PR TITLE
fix deadlock that occured, while shutting down Resource[F, JmsConnector[F]]

### DIFF
--- a/connectors/activemq/src/main/scala/com/ocadotechnology/pass4s/connectors/activemq/taps.scala
+++ b/connectors/activemq/src/main/scala/com/ocadotechnology/pass4s/connectors/activemq/taps.scala
@@ -142,8 +142,8 @@ private[activemq] object taps {
   }
 
   private def subscriberStream[F[_], A](subscriber: SinkQueueWithCancel[A])(implicit F: Async[F]): Stream[F, A] = {
-    val pull = Async[F].fromFuture(F.delay(subscriber.pull()))
     val cancel = F.delay(subscriber.cancel())
+    val pull = Async[F].fromFutureCancelable(F.delay((subscriber.pull(), cancel)))
     Stream.repeatEval(pull).unNoneTerminate.onFinalize(cancel)
   }
 


### PR DESCRIPTION
https://github.com/typelevel/cats-effect/releases/tag/v3.5.0

since CE 3.5.0+ all usages of `async` and derivatives should be reviewed.

i reviewed all usages of `fromFuture`, `async`, `async_` and found 1 bug:
* fix deadlock that occured, while shutting down Resource[F, JmsConnector[F]]