### PR TITLE
update sbt-typelevel to 0.7.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,72 +15,61 @@ on:
     tags: [v*]
 
 env:
-  PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-  SONATYPE_CREDENTIAL_HOST: ${{ secrets.SONATYPE_CREDENTIAL_HOST }}
-  SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-  PGP_SECRET: ${{ secrets.PGP_SECRET }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+concurrency:
+  group: ${{ github.workflow }} @ ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    name: Build and Test
+    name: Test
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        scala: [2.13.12]
+        os: [ubuntu-22.04]
+        scala: [2.13]
         java: [graalvm@21]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Download Java (graalvm@21)
-        id: download-java-graalvm-21
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Setup Java (graalvm@21)
+        id: setup-java-graalvm-21
         if: matrix.java == 'graalvm@21'
-        uses: typelevel/download-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: graalvm
           java-version: 21
+          cache: sbt
 
-      - name: Setup Java (graalvm@21)
-        if: matrix.java == 'graalvm@21'
-        uses: actions/setup-java@v3
-        with:
-          distribution: jdkfile
-          java-version: 21
-          jdkFile: ${{ steps.download-java-graalvm-21.outputs.jdkFile }}
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+      - name: sbt update
+        if: matrix.java == 'graalvm@21' && steps.setup-java-graalvm-21.outputs.cache-hit == 'false'
+        run: sbt +update
 
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'graalvm@21' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'graalvm@21' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
         run: sbt '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
-        if: matrix.java == 'graalvm@21' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'graalvm@21' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'graalvm@21' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'graalvm@21' && matrix.os == 'ubuntu-22.04'
         run: sbt '++ ${{ matrix.scala }}' doc
 
       - name: Integration tests
@@ -88,15 +77,15 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p core/target addons/phobos/target target addons/extra/target demo/target addons/plaintext/target connectors/activemq-pekko/target connectors/sns/target mdoc/target addons/s3proxy/target connectors/kinesis/target connectors/sqs/target kernel/target addons/logging/target connectors/activemq/target addons/circe/target high/target project/target
+        run: mkdir -p core/target addons/phobos/target addons/extra/target addons/plaintext/target connectors/activemq-pekko/target connectors/sns/target mdoc/target addons/s3proxy/target connectors/kinesis/target connectors/sqs/target kernel/target addons/logging/target connectors/activemq/target addons/circe/target high/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar core/target addons/phobos/target target addons/extra/target demo/target addons/plaintext/target connectors/activemq-pekko/target connectors/sns/target mdoc/target addons/s3proxy/target connectors/kinesis/target connectors/sqs/target kernel/target addons/logging/target connectors/activemq/target addons/circe/target high/target project/target
+        run: tar cf targets.tar core/target addons/phobos/target addons/extra/target addons/plaintext/target connectors/activemq-pekko/target connectors/sns/target mdoc/target addons/s3proxy/target connectors/kinesis/target connectors/sqs/target kernel/target addons/logging/target connectors/activemq/target addons/circe/target high/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
           path: targets.tar
@@ -107,76 +96,119 @@ jobs:
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [graalvm@21]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Download Java (graalvm@21)
-        id: download-java-graalvm-21
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Setup Java (graalvm@21)
+        id: setup-java-graalvm-21
         if: matrix.java == 'graalvm@21'
-        uses: typelevel/download-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: graalvm
           java-version: 21
+          cache: sbt
 
-      - name: Setup Java (graalvm@21)
-        if: matrix.java == 'graalvm@21'
-        uses: actions/setup-java@v3
+      - name: sbt update
+        if: matrix.java == 'graalvm@21' && steps.setup-java-graalvm-21.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Download target directories (2.13)
+        uses: actions/download-artifact@v4
         with:
-          distribution: jdkfile
-          java-version: 21
-          jdkFile: ${{ steps.download-java-graalvm-21.outputs.jdkFile }}
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13
 
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
-
-      - name: Download target directories (2.13.12)
-        uses: actions/download-artifact@v3
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.12
-
-      - name: Inflate target directories (2.13.12)
+      - name: Inflate target directories (2.13)
         run: |
           tar xf targets.tar
           rm targets.tar
 
       - name: Import signing key
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''
-        run: echo $PGP_SECRET | base64 -di | gpg --import
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+        run: echo $PGP_SECRET | base64 -d -i - | gpg --import
 
       - name: Import signing key and strip passphrase
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE != ''
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: |
-          echo "$PGP_SECRET" | base64 -di > /tmp/signing-key.gpg
+          echo "$PGP_SECRET" | base64 -d -i - > /tmp/signing-key.gpg
           echo "$PGP_PASSPHRASE" | gpg --pinentry-mode loopback --passphrase-fd 0 --import /tmp/signing-key.gpg
           (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
 
       - name: Publish
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_CREDENTIAL_HOST: ${{ secrets.SONATYPE_CREDENTIAL_HOST }}
         run: sbt tlCiRelease
+
+  dependency-submission:
+    name: Submit Dependencies
+    if: github.event.repository.fork == false && github.event_name != 'pull_request'
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        java: [graalvm@21]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Setup Java (graalvm@21)
+        id: setup-java-graalvm-21
+        if: matrix.java == 'graalvm@21'
+        uses: actions/setup-java@v4
+        with:
+          distribution: graalvm
+          java-version: 21
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'graalvm@21' && steps.setup-java-graalvm-21.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Submit Dependencies
+        uses: scalacenter/sbt-dependency-submission@v2
+        with:
+          modules-ignore: pass4s_2.13 pass4s-demo_2.13
+          configs-ignore: test scala-tool scala-doc-tool test-internal
 
   validate-steward:
     name: Validate Steward Config
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
+        java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (fast)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Setup Java (temurin@11)
+        id: setup-java-temurin-11
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
 
       - uses: coursier/setup-action@v1
         with:

--- a/addons/logging/src/main/scala/com/ocadotechnology/pass4s/logging/LoggingSyntax.scala
+++ b/addons/logging/src/main/scala/com/ocadotechnology/pass4s/logging/LoggingSyntax.scala
@@ -116,9 +116,9 @@ object syntax {
                 _.map {
                   _.mapScope {
                     _.flatTap { payload =>
-                      /** Note: this logs *after* the resource has been acquired (which is the only place where we'll see a message, so it
-                        * makes sense) and *before* the resource is closed.
-                        */
+                      /* Note: this logs *after* the resource has been acquired (which is the only place where we'll see a message, so it
+                       * makes sense) and *before* the resource is closed.
+                       */
                       Resource.eval(logger.debug(s"Received message [$payload] from [$source]")).onFinalizeCase {
                         case ExitCase.Succeeded  => logger.debug(s"Committing message [$payload]")
                         case ExitCase.Canceled   => logger.warn(s"Rolling back message [$payload] because of cancelation")

--- a/addons/phobos/src/test/scala/com/ocadotechnology/pass4s/phobos/PhobosTests.scala
+++ b/addons/phobos/src/test/scala/com/ocadotechnology/pass4s/phobos/PhobosTests.scala
@@ -28,6 +28,7 @@ import ru.tinkoff.phobos.derivation.semiauto._
 import ru.tinkoff.phobos.encoding.XmlEncoder
 import weaver.SimpleIOSuite
 
+import scala.annotation.nowarn
 import scala.reflect.runtime.universe._
 
 object PhobosTests extends SimpleIOSuite {
@@ -36,6 +37,7 @@ object PhobosTests extends SimpleIOSuite {
 
   case class MyEvent(foo: Int, bar: String)
 
+  @nowarn
   object MyEvent {
     implicit val xmlEncoder: XmlEncoder[MyEvent] = deriveXmlEncoder("journey")
     implicit val xmlDecoder: XmlDecoder[MyEvent] = deriveXmlDecoder("journey")

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ ThisBuild / githubWorkflowBuild ++= Seq(
     name = Some("Integration tests")
   )
 )
+ThisBuild / tlJdkRelease := None
 
 val Versions = new {
   val ActiveMq = "5.18.3"

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 ThisBuild / tlBaseVersion := "0.4" // current series x.y
 
+ThisBuild / startYear := Some(2023)
 ThisBuild / organization := "com.ocadotechnology"
 ThisBuild / organizationName := "Ocado Technology"
 ThisBuild / licenses := Seq(License.Apache2)

--- a/build.sbt
+++ b/build.sbt
@@ -256,7 +256,7 @@ lazy val commonSettings = Seq(
 )
 
 val compilerOptions =
-  scalacOptions -= "-Xfatal-warnings"
+  scalacOptions --= Seq("-Xfatal-warnings", "-Xsource:3")
 
 val compilerPlugins = Seq(
   compilerPlugin("org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full),

--- a/connectors/activemq-pekko/src/main/scala/com/ocadotechnology/pass4s/connectors/activemq/producer.scala
+++ b/connectors/activemq-pekko/src/main/scala/com/ocadotechnology/pass4s/connectors/activemq/producer.scala
@@ -53,10 +53,10 @@ private[activemq] object producer {
   ): Resource[F, MessageProducer[F]] =
     for {
       queue <- Resource.eval(Queue.bounded[F, JmsPayload[F]](bufferSize))
-      /** Stream.eval(queue.take) wouldn't work here because it takes only single element and terminates. In this case we need to take all
-        * elements but one by one as long as there's anything in the queue. Limit is set to one as we only process single message at a time,
-        * so that we don't reemit chukns in case of failure.
-        */
+      /* Stream.eval(queue.take) wouldn't work here because it takes only single element and terminates. In this case we need to take all
+       * elements but one by one as long as there's anything in the queue. Limit is set to one as we only process single message at a time,
+       * so that we don't reemit chukns in case of failure.
+       */
       _ <- Stream.fromQueueUnterminated(queue, limit = 1).through(sendMessageAndCompletePromise(connectionFactory)).compile.drain.background
     } yield enqueueAndWaitForPromise[F](queue.offer)
 

--- a/connectors/activemq/src/main/scala/com/ocadotechnology/pass4s/connectors/activemq/producer.scala
+++ b/connectors/activemq/src/main/scala/com/ocadotechnology/pass4s/connectors/activemq/producer.scala
@@ -53,10 +53,10 @@ private[activemq] object producer {
   ): Resource[F, MessageProducer[F]] =
     for {
       queue <- Resource.eval(Queue.bounded[F, JmsPayload[F]](bufferSize))
-      /** Stream.eval(queue.take) wouldn't work here because it takes only single element and terminates. In this case we need to take all
-        * elements but one by one as long as there's anything in the queue. Limit is set to one as we only process single message at a time,
-        * so that we don't reemit chukns in case of failure.
-        */
+      /* Stream.eval(queue.take) wouldn't work here because it takes only single element and terminates. In this case we need to take all
+       * elements but one by one as long as there's anything in the queue. Limit is set to one as we only process single message at a time,
+       * so that we don't reemit chukns in case of failure.
+       */
       _ <- Stream.fromQueueUnterminated(queue, limit = 1).through(sendMessageAndCompletePromise(connectionFactory)).compile.drain.background
     } yield enqueueAndWaitForPromise[F](queue.offer)
 

--- a/kernel/src/main/scala/com/ocadotechnology/pass4s/kernel/Consumer.scala
+++ b/kernel/src/main/scala/com/ocadotechnology/pass4s/kernel/Consumer.scala
@@ -55,7 +55,7 @@ trait Consumer[F[_], +A] extends ((A => F[Unit]) => F[Unit]) with Serializable {
   //
   //
 
-  /** Starts the consumer, passing every message through the processing function `f`. Think of it like of an `evalMap` on [[Stream]] or
+  /** Starts the consumer, passing every message through the processing function `f`. Think of it like of an `evalMap` on [[fs2.Stream]] or
     * `use` on [[cats.effect.Resource]].
     *
     * For consumers built from an infinite-stream Connector (which every connector you ever use is going to be), this never terminates. For
@@ -275,7 +275,7 @@ object Consumer extends ConsumerInstances {
     ): Consumer[F, B] =
       Consumer.fromFunction[F, B](handler => self.consume(f(_).flatMap(_.fold(Applicative[F].unit)(handler))))
 
-    /** Similar to [[mapM()]], but discards the result of the tapped effect.
+    /** Similar to [[mapM]], but discards the result of the tapped effect.
       */
     def contraTapM(
       f: A => F[Unit]
@@ -296,7 +296,7 @@ object Consumer extends ConsumerInstances {
       use => self.consume(msg => use(msg) >> f(msg))
 
     /** For every message, creates an artificial consumer that only handles that one message, and runs it through the given function. This
-      * follows [[Consumer#flatMap]] semantics, so while the consumer of `B` is busy processing, no further messages will be received by
+      * follows `Consumer#flatMap` semantics, so while the consumer of `B` is busy processing, no further messages will be received by
       * `self`.
       */
     def selfProduct[B](

--- a/kernel/src/main/scala/com/ocadotechnology/pass4s/kernel/Sender.scala
+++ b/kernel/src/main/scala/com/ocadotechnology/pass4s/kernel/Sender.scala
@@ -81,7 +81,7 @@ trait Sender[F[_], -A] extends (A => F[Unit]) with Serializable {
   def prepare[B](f: B => A): Sender[F, B] = contramap(f)
 
   /** Returns a sender that, based on whether the input is a Left or a Right, chooses the sender that will receive the message - for Lefts
-    * it'll be [[this]], for Rights it'll be [[another]].
+    * it'll be `this`, for Rights it'll be `another`.
     */
   def or[B](another: Sender[F, B]): Sender[F, Either[A, B]] = Sender.decide(this, another)
 }
@@ -174,7 +174,7 @@ object Sender extends SenderInstances {
       messages.traverse_(self.sendOne)
 
     /** This can be used together with [[Sender.writer]] or [[Sender.chainWriter]]: After you've sent some messages with a writer sender,
-      * you can pass the result to actualSender.sendWritten(...). This will perform the actual send using the underlying sender ([[self]]).
+      * you can pass the result to actualSender.sendWritten(...). This will perform the actual send using the underlying sender (`self`).
       *
       * Also see [[sendWrittenK]].
       */
@@ -236,8 +236,8 @@ object Sender extends SenderInstances {
     ): Sender[F, B] =
       fromFunction(f(_).flatMap(_.fold(F.unit)(self.sendOne)))
 
-    /** The dual to [[Sender.or]] - sends both parts of the tuple to the right underlying sender ([[self]] or [[another]], based on the
-      * position in the tuple).
+    /** The dual to [[Sender.or]] - sends both parts of the tuple to the right underlying sender (`self` or `another`, based on the position
+      * in the tuple).
       *
       * This is the same as .tupled from Cats syntax.
       */

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.4")
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.22")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.7.7")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.4.0")

--- a/src/it/scala/com/ocadotechnology/pass4s/addons/s3proxy/S3ProxyTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/addons/s3proxy/S3ProxyTests.scala
@@ -33,8 +33,10 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import weaver.MutableIOSuite
 import fs2.Stream
 
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 
+@nowarn
 object S3ProxyTests extends MutableIOSuite {
 
   override type Res = (Broker[IO, Sns with Sqs], S3Client[IO], SnsConnector.SnsConnector[IO], SqsConnector.SqsConnector[IO])

--- a/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SnsTests.scala
+++ b/src/it/scala/com/ocadotechnology/pass4s/connectors/snssqs/SnsTests.scala
@@ -29,6 +29,9 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import weaver.MutableIOSuite
 
+import scala.annotation.nowarn
+
+@nowarn
 object SnsTests extends MutableIOSuite {
   override type Res = (Broker[IO, Sns with SnsFifo with Sqs with SqsFifo], SnsAsyncClientOp[IO], SqsAsyncClientOp[IO])
 


### PR DESCRIPTION
* startYear is now not added by default by sbt-typelevel ([changelog](https://github.com/typelevel/sbt-typelevel/releases/tag/v0.7.0))
* Don't explicitly target a JDK release, since now sbt-typelevel sets the default to 8 ([changelog](https://github.com/typelevel/sbt-typelevel/releases/tag/v0.5.0))
  * `java.util.Enumeration[E].asIterator()` is used within the project and it was added in Java 9
* Still don't use `"-Xsource:3"` to prevent all of the needed changes that will be prepared in a separate PR
* Changes in Scaladoc were done to prevent fatal warnings upon `sbt doc`