### PR TITLE
Configure scala steward to always update pull requests

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,4 @@
+updatePullRequests = "always"
 updates.ignore = [
   # https://www.lightbend.com/blog/why-we-are-changing-the-license-for-akka
   { groupId = "com.typesafe.akka" },


### PR DESCRIPTION
```
# If "on-conflicts", Scala Steward will update the PR it created to resolve conflicts as
# long as you don't change it yourself.
# If "always", Scala Steward will always update the PR it created as long as
# you don't change it yourself.
# If "never", Scala Steward will never update the PR
# Default: "on-conflicts"
updatePullRequests = "always"
```